### PR TITLE
Fixing the pie duplication bug for fabric 1.20.1

### DIFF
--- a/fabric/src/main/java/com/chefmooon/frightsdelight/common/registry/fabric/FrightsDelightBlocksImpl.java
+++ b/fabric/src/main/java/com/chefmooon/frightsdelight/common/registry/fabric/FrightsDelightBlocksImpl.java
@@ -90,20 +90,20 @@ public class FrightsDelightBlocksImpl {
                     BlockBehaviour.Properties.copy(Blocks.GLASS).strength(2.0F).sound(SoundType.GLASS)));
 
     public static final Block ROTTEN_FLESH_PIE = registerBlock(FrightsDelightBlocks.ROTTEN_FLESH_PIE,
-            new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE), () -> FrightsDelightItemsImpl.ROTTEN_FLESH_PIE));
+            new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE), () -> FrightsDelightItemsImpl.ROTTEN_FLESH_PIE_SLICE));
     public static final Block SLIMEAPPLE_PIE = registerBlock(FrightsDelightBlocks.SLIMEAPPLE_PIE,
             new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE).lightLevel(FrightsDelightBlocks.slimeApplePieLight()),
-                    () -> FrightsDelightItemsImpl.SLIMEAPPLE_PIE));
+                    () -> FrightsDelightItemsImpl.SLIMEAPPLE_PIE_SLICE));
     public static final Block SPIDEREYE_PIE = registerBlock(FrightsDelightBlocks.SPIDEREYE_PIE,
-            new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE), () -> FrightsDelightItemsImpl.SPIDEREYE_PIE));
+            new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE), () -> FrightsDelightItemsImpl.SPIDEREYE_PIE_SLICE));
     public static final Block GHASTTEAR_PIE = registerBlock(FrightsDelightBlocks.GHASTTEAR_PIE,
-            new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE), () -> FrightsDelightItemsImpl.GHASTTEAR_PIE));
+            new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE), () -> FrightsDelightItemsImpl.GHASTTEAR_PIE_SLICE));
     public static final Block SOUL_BERRY_CHEESECAKE = registerBlock(FrightsDelightBlocks.SOUL_BERRY_CHEESECAKE,
             new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE), () -> FrightsDelightItemsImpl.SOUL_BERRY_CHEESECAKE_SLICE));
     public static final Block WITHER_BERRY_CHEESECAKE = registerBlock(FrightsDelightBlocks.WITHER_BERRY_CHEESECAKE,
             new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE), () -> FrightsDelightItemsImpl.WITHER_BERRY_CHEESECAKE_SLICE));
     public static final Block COBWEB_PIE = registerBlock(FrightsDelightBlocks.COBWEB_PIE,
-            new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE), () -> FrightsDelightItemsImpl.COBWEB_PIE));
+            new PieBlock(BlockBehaviour.Properties.copy(Blocks.CAKE), () -> FrightsDelightItemsImpl.COBWEB_PIE_SLICE));
 
     public static final Block ROTTEN_FLESH_SYRUP = registerBlock(FrightsDelightBlocks.ROTTEN_FLESH_SYRUP,
             new LiquidBlock(FrightsDelightFluids.ROTTEN_FLESH_SYRUP, BlockBehaviour.Properties.copy(Blocks.WATER)));


### PR DESCRIPTION
When cutting a pie block, instead of pie slices, the entire pie drops out, allowing you to continuously duplicate pies.

https://github.com/user-attachments/assets/dff2d0d4-fabd-4a28-bc16-aacff4bcc584

https://github.com/user-attachments/assets/7fd13199-d987-440a-ba0b-924900b65a8b
